### PR TITLE
Improve release note

### DIFF
--- a/github-release.sh
+++ b/github-release.sh
@@ -80,4 +80,5 @@ github-release edit \
   --user $CIRCLE_PROJECT_USERNAME \
   --repo $CIRCLE_PROJECT_REPONAME \
   --tag $RUBY_VERSION \
+  --name "Ruby-${RUBY_VERSION}" \
   --description "$(cat description.md)"

--- a/github-release.sh
+++ b/github-release.sh
@@ -55,7 +55,7 @@ Build on CentOS 7
 EOS
 
 # CentOS 7
-for i in *.el7.centos.x86_64.rpm; do
+for i in *.el7.centos.x86_64.rpm *.el7.centos.src.rpm; do
   print_rpm_markdown $i >> description.md
   upload_rpm $i
 done
@@ -67,7 +67,7 @@ Build on CentOS 6
 EOS
 
 # CentOS 6
-for i in *.el6.x86_64.rpm; do
+for i in *.el6.x86_64.rpm *.el6.src.rpm; do
   print_rpm_markdown $i >> description.md
   upload_rpm $i
 done

--- a/rubybuild.sh
+++ b/rubybuild.sh
@@ -7,3 +7,4 @@ cd $HOME/rpmbuild/SOURCES && curl -LO https://cache.ruby-lang.org/pub/ruby/$RUBY
 rpmbuild -ba $HOME/rpmbuild/SPECS/ruby.spec
 
 cp $HOME/rpmbuild/RPMS/x86_64/* /shared/
+cp $HOME/rpmbuild/SRPMS/* /shared/


### PR DESCRIPTION
* 以前のリリースノート: https://github.com/feedforce/ruby-rpm/releases/tag/2.2.3
* 現在のリリースノート: https://github.com/feedforce/ruby-rpm/releases/tag/2.3.0

以前のリリースノートと（多分）同じ書式になる PR です。

* `Use at your own risk!` は責任回避のため付けたい
* CentOS 7 と CentOS 6 で分けて見やすく
* sha256 の行をすっきりと

### 悩んでいる

* どうやって確認すれば良い？

### 些細な疑問

* SRPM をアップロードしなくなったのはなにか理由がある？
* リリース名が Ruby-2.2.3 から 2.3.0 とかに変わったのはなにか理由がある？