### PR TITLE
Fix ruby.spec path

### DIFF
--- a/script/github-release.sh
+++ b/script/github-release.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-RUBY_VERSION=$(grep "%define \+rubyver" $HOME/rpmbuild/SPECS/ruby.spec | awk '{print $3}')
+RUBY_VERSION=$(grep "%define \+rubyver" ruby.spec | awk '{print $3}')
 
 need_to_release() {
 	http_code=$(curl -sL -w "%{http_code}\\n" https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${RUBY_VERSION} -o /dev/null)

--- a/script/github-release.sh
+++ b/script/github-release.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-RUBY_VERSION=$(grep "%define \+rubyver" ruby.spec | awk '{print $3}')
+RUBY_VERSION=$(grep "%define \+rubyver" $HOME/$CIRCLE_PROJECT_REPONAME/ruby.spec | awk '{print $3}')
 
 need_to_release() {
 	http_code=$(curl -sL -w "%{http_code}\\n" https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${RUBY_VERSION} -o /dev/null)


### PR DESCRIPTION
`github-release.sh`上で指定するruby.specのPATHがdockerコンテナ内のpathを指定していたため、releaseに失敗していました。CircleCIのコンテナを指定するように変更しました。

絶対パスで指定した方がよかったかも。