### PR TITLE
Add slack notification for only master branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,3 +16,8 @@ deployment:
     branch: master
     commands:
       - ./script/github-release.sh
+experimental:
+  notify:
+    branches:
+      only:
+        - master


### PR DESCRIPTION
↓ master にマージされたときだけ、このような通知をする PR です。
![image](https://cloud.githubusercontent.com/assets/170014/20507338/6e4ef8fa-b09d-11e6-98c0-af1371e43d71.png)

Slack の通知先は #tech です。[Slack の in-comming WebHook を作って](https://circleci.com/gh/feedforce/ruby-rpm/edit#hooks)、[CircleCI に設定](https://circleci.com/gh/feedforce/ruby-rpm/edit#hooks)しました。
