### PR TITLE
Revert "Add slack notification for only master branch"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,3 @@ deployment:
     branch: master
     commands:
       - ./script/github-release.sh
-experimental:
-  notify:
-    branches:
-      only:
-        - master


### PR DESCRIPTION
Reverts feedforce/ruby-rpm#37

[リリースページ](https://github.com/feedforce/ruby-rpm/releases)に普通に[フィードがあった](https://github.com/feedforce/ruby-rpm/releases.atom)ので、Slack でこちらを購読することにします。

CircleCI と Slack の設定も元に戻しました。