### PR TITLE
Fix Obsoletes in ruby.spec

### DIFF
--- a/ruby.spec
+++ b/ruby.spec
@@ -17,11 +17,15 @@ Provides: ruby-rdoc
 Provides: ruby-libs
 Provides: ruby-devel
 Provides: rubygems
-Obsoletes: ruby
-Obsoletes: ruby-libs
-Obsoletes: ruby-irb
-Obsoletes: ruby-rdoc
-Obsoletes: ruby-devel
+Obsoletes: ruby < %{rubyver}
+Obsoletes: ruby-devel < %{rubyver}
+Obsoletes: ruby-irb < %{rubyver}
+Obsoletes: ruby-libs < %{rubyver}
+Obsoletes: rubygem-bigdecimal
+Obsoletes: rubygem-io-console
+Obsoletes: rubygem-json
+Obsoletes: rubygem-psych
+Obsoletes: rubygem-rdoc
 Obsoletes: rubygems
 
 %description


### PR DESCRIPTION
closes #33

## 背景

https://github.com/hansode/ruby-2.1.x-rpm/issues/5 で指摘があった件。

ただ、我々は yum repository を管理していないこともあり、私はあまり分かっていないし、問題を発生させられてもいない。


このリポジトリの Ruby RPM を使わずに、普通に `$ yum install ruby ruby-devel` すると、このようなパッケージがインストールされる。

```
============================================================================
 Package                      Arch    Version             Repository   Size
============================================================================
Installing:
 ruby                         x86_64  2.0.0.598-25.el7_1  base         67 k
 ruby-devel                   x86_64  2.0.0.598-25.el7_1  base        127 k
Installing for dependencies:
 ruby-irb                     noarch  2.0.0.598-25.el7_1  base         88 k
 ruby-libs                    x86_64  2.0.0.598-25.el7_1  base        2.8 M
 rubygem-bigdecimal           x86_64  1.2.0-25.el7_1      base         79 k
 rubygem-io-console           x86_64  0.4.2-25.el7_1      base         50 k
 rubygem-json                 x86_64  1.7.7-25.el7_1      base         75 k
 rubygem-psych                x86_64  2.0.0-25.el7_1      base         77 k
 rubygem-rdoc                 noarch  4.0.0-25.el7_1      base        318 k
 rubygems                     noarch  2.0.14-25.el7_1     base        212 k

Transaction Summary
============================================================================
```

以上のパッケージをインストールした状態で、このリポジトリの Ruby RPM をインストールしようとした時の挙動を改善すれば良いと思う。

参考までに現在は[以下の設定](https://github.com/feedforce/ruby-rpm/blob/2.3.3/ruby.spec#L20-L25)にしている。バージョンを指定する以外にも rubygem-bigdecimal を追加するなどしたほうが良いと思った。

```
Obsoletes: ruby
Obsoletes: ruby-libs
Obsoletes: ruby-irb
Obsoletes: ruby-rdoc
Obsoletes: ruby-devel
Obsoletes: rubygems
```

## どうなった？

### 修正前

Obsolete package がインストールされているというエラーになる。

```
[root@373f536e22b7 rpmbuild]# rpm -ivh /shared/backup/ruby-2.3.3-1.el7.centos.x86_64.rpm
error: Failed dependencies:
        ruby is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        ruby-libs is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        ruby-irb is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        ruby-devel is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygems is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
```

※ 指定している RPM は https://github.com/feedforce/ruby-rpm/releases/tag/2.3.3

### 修正後

指摘される Obsolete package が増えた。一部はバージョンも付いている。

```
[root@373f536e22b7 rpmbuild]# rpm -ivh /shared/ruby-2.3.3-1.el7.centos.x86_64.rpm
error: Failed dependencies:
        ruby < 2.3.3 is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        ruby-devel < 2.3.3 is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        ruby-irb < 2.3.3 is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        ruby-libs < 2.3.3 is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygem-bigdecimal is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygem-io-console is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygem-json is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygem-psych is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygem-rdoc is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
        rubygems is obsoleted by ruby-2.3.3-1.el7.centos.x86_64
```

※ 指定している RPM はこのブランチで作ったもの

@sakuro
もしなにかご存知でしたら、アドバイスお願いします。
