### PR TITLE
Bump Ruby to 2.3.5

### DIFF
--- a/ruby.spec
+++ b/ruby.spec
@@ -1,4 +1,4 @@
-%define rubyver         2.3.4
+%define rubyver         2.3.5
 
 Name:           ruby
 Version:        %{rubyver}
@@ -67,6 +67,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
+* Mon Oct 23 2017 Tsubasa Takayama <t-takayama@feedforce.jp> - 2.3.5
+- Update ruby version to 2.3.5
+
 * Fri Sep 15 2017 Masataka Suzuki <koshigoe@feedforce.jp> - 2.4.2
 - Update ruby version to 2.4.2
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/

## 補足

d8ee72ae2d43ce5781aa21e2981fe45989723a8c で `ruby-2.3` ブランチの変更を残しつつ、 master との差分をいい感じにマージ済み。