### PR TITLE
Bump ruby to 2.4.3

### DIFF
--- a/ruby.spec
+++ b/ruby.spec
@@ -1,4 +1,4 @@
-%define rubyver         2.4.2
+%define rubyver         2.4.3
 
 Name:           ruby
 Version:        %{rubyver}
@@ -67,6 +67,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
+* Fri Dec 15 2017 Masataka Suzuki <koshigoe@feedforce.jp> - 2.4.3
+- Update ruby version to 2.4.3
+
 * Fri Sep 15 2017 Masataka Suzuki <koshigoe@feedforce.jp> - 2.4.2
 - Update ruby version to 2.4.2
 


### PR DESCRIPTION
[Ruby 2.4.3 リリース](https://www.ruby-lang.org/ja/news/2017/12/14/ruby-2-4-3-released/)