### PR TITLE
Bump ruby to 2.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           name: Copy SPEC file
           command: cp ~/ruby-rpm/ruby.spec ./SPECS/
       - run:
+          name: Copy patch file
+          command: cp ~/ruby-rpm/prelude.c.patch ./SOURCES/
+      - run:
           name: Build Ruby RPM
           command: |
             RUBY_X_Y_Z_VERSION=$(grep "%define \+rubyver" ./SPECS/ruby.spec | awk '{print $3}')

--- a/prelude.c.patch
+++ b/prelude.c.patch
@@ -1,0 +1,39 @@
+--- prelude.c.orig	2017-12-25 16:01:07.000000000 +0900
++++ prelude.c	2017-12-26 17:46:31.968287203 +0900
+@@ -197,13 +197,13 @@
+ 
+ 
+ #define PRELUDE_STR(n) rb_usascii_str_new_static(prelude_##n.L0, sizeof(prelude_##n))
+-static void
+-prelude_eval(VALUE code, VALUE name, int line)
+-{
+ #ifdef __GNUC__
+ # pragma GCC diagnostic push
+ # pragma GCC diagnostic error "-Wmissing-field-initializers"
+ #endif
++static void
++prelude_eval(VALUE code, VALUE name, int line)
++{
+     static const rb_compile_option_t optimization = {
+ 	TRUE, /* int inline_const_cache; */
+ 	TRUE, /* int peephole_optimization; */
+@@ -217,9 +217,6 @@
+ 	FALSE, /* unsigned int coverage_enabled; */
+ 	0, /* int debug_level; */
+     };
+-#ifdef __GNUC__
+-# pragma GCC diagnostic pop
+-#endif
+ 
+     rb_ast_t *ast = rb_parser_compile_string_path(rb_parser_new(), name, code, line);
+     if (!ast->root) {
+@@ -230,6 +227,9 @@
+ 				      NULL, ISEQ_TYPE_TOP, &optimization));
+     rb_ast_dispose(ast);
+ }
++#ifdef __GNUC__
++# pragma GCC diagnostic pop
++#endif
+ 
+ void
+ Init_prelude(void)

--- a/ruby.spec
+++ b/ruby.spec
@@ -9,6 +9,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       readline ncurses gdbm glibc openssl libyaml libffi zlib
 BuildRequires:  readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel make libyaml-devel libffi-devel zlib-devel
 Source0:        ftp://ftp.ruby-lang.org/pub/ruby/ruby-%{rubyver}.tar.gz
+# See https://bugs.ruby-lang.org/issues/14234
+Patch:          prelude.c.patch
 Summary:        An interpreter of object-oriented scripting language
 Group:          Development/Languages
 Provides: ruby(abi) = 2.5
@@ -36,6 +38,7 @@ straight-forward, and extensible.
 
 %prep
 %setup -n ruby-%{rubyver}
+%patch -p0
 
 %build
 export CFLAGS="$RPM_OPT_FLAGS -Wall -fno-strict-aliasing"

--- a/ruby.spec
+++ b/ruby.spec
@@ -70,7 +70,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
-* Fri Dec 15 2017 Takashi Masuda <masutaka@feedforce.jp> - 2.5.0
+* Mon Dec 25 2017 Takashi Masuda <masutaka@feedforce.jp> - 2.5.0
 - Update ruby version to 2.5.0
 
 * Fri Dec 15 2017 Masataka Suzuki <koshigoe@feedforce.jp> - 2.4.3

--- a/ruby.spec
+++ b/ruby.spec
@@ -1,4 +1,4 @@
-%define rubyver         2.4.3
+%define rubyver         2.5.0
 
 Name:           ruby
 Version:        %{rubyver}
@@ -11,7 +11,7 @@ BuildRequires:  readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-
 Source0:        ftp://ftp.ruby-lang.org/pub/ruby/ruby-%{rubyver}.tar.gz
 Summary:        An interpreter of object-oriented scripting language
 Group:          Development/Languages
-Provides: ruby(abi) = 2.4
+Provides: ruby(abi) = 2.5
 Provides: ruby-irb
 Provides: ruby-rdoc
 Provides: ruby-libs
@@ -67,6 +67,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
+* Fri Dec 15 2017 Takashi Masuda <masutaka@feedforce.jp> - 2.5.0
+- Update ruby version to 2.5.0
+
 * Fri Dec 15 2017 Masataka Suzuki <koshigoe@feedforce.jp> - 2.4.3
 - Update ruby version to 2.4.3
 


### PR DESCRIPTION
[Ruby 2.5.0 リリース](https://www.ruby-lang.org/ja/news/2017/12/25/ruby-2-5-0-released/)