### PR TITLE
Fix wrong tagging on ruby-2.3 branch

### DIFF
--- a/.circleci/github-release.sh
+++ b/.circleci/github-release.sh
@@ -34,7 +34,8 @@ $HOME/bin/github-release release \
   --repo $CIRCLE_PROJECT_REPONAME \
   --tag $RUBY_VERSION \
   --name "Ruby-${RUBY_VERSION}" \
-  --description "not release"
+  --description "not release" \
+  --target ruby-2.3
 
 #
 # Upload rpm files and build a release note


### PR DESCRIPTION
https://circleci.com/workflow-run/e3405727-af67-4ec6-8e54-5b1098341374 によりリリースされた https://github.com/feedforce/ruby-rpm/releases/tag/2.3.6 を見た感じ、またタグがおかしい。

どうやら [github-release コマンド](https://github.com/aktau/github-release)をダウンロードして確認した感じ、デフォルトのタグ付け位置は GitHub の default branch のようだ。

```
$ ./github-release --help
Usage: github-release [global options] <verb> [verb options]

(snip)

Verbs:
(snip)
    release:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to create a release from (*)
        -n, --name           Name of the release (defaults to tag)
        -d, --description    Release description, use - for reading a description from stdin (defaults to tag)
        -c, --target         Commit SHA or branch to create release of (defaults to the repository default branch)
            --draft          The release is a draft
        -p, --pre-release    The release is a pre-release
(snip)
```

`--target` オプションを指定してみる。