### PR TITLE
Make branches like ruby-2.3 easy to make

### DIFF
--- a/.circleci/github-release.sh
+++ b/.circleci/github-release.sh
@@ -34,7 +34,8 @@ $HOME/bin/github-release release \
   --repo $CIRCLE_PROJECT_REPONAME \
   --tag $RUBY_VERSION \
   --name "Ruby-${RUBY_VERSION}" \
-  --description "not release"
+  --description "not release" \
+  --target master
 
 #
 # Upload rpm files and build a release note


### PR DESCRIPTION
PR #55 の master への反映。

今後、ruby-2.4 みたいなブランチを作る時のヒントになるように、master にも修正を反映しました。

CI が通ったらセルフマージします。