### PR TITLE
Bump ruby version to 2.4.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,4 +66,4 @@ workflows:
           filters:
               branches:
                 only:
-                  - master
+                  - ruby-2.4

--- a/.circleci/github-release.sh
+++ b/.circleci/github-release.sh
@@ -35,7 +35,7 @@ $HOME/bin/github-release release \
   --tag $RUBY_VERSION \
   --name "Ruby-${RUBY_VERSION}" \
   --description "not release" \
-  --target master
+  --target ruby-2.4
 
 #
 # Upload rpm files and build a release note

--- a/ruby.spec
+++ b/ruby.spec
@@ -1,4 +1,4 @@
-%define rubyver         2.5.1
+%define rubyver         2.4.4
 
 Name:           ruby
 Version:        %{rubyver}
@@ -11,7 +11,7 @@ BuildRequires:  readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-
 Source0:        ftp://ftp.ruby-lang.org/pub/ruby/ruby-%{rubyver}.tar.gz
 Summary:        An interpreter of object-oriented scripting language
 Group:          Development/Languages
-Provides: ruby(abi) = 2.5
+Provides: ruby(abi) = 2.4
 Provides: ruby-irb
 Provides: ruby-rdoc
 Provides: ruby-libs
@@ -67,6 +67,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
+
+* Wed Apr 18 2018 Tsubasa Takayama <t-takayama@feedforce.jp> - 2.4.4
+- Update ruby version to 2.4.4
 
 * Thu Mar 29 2018 Masataka Suzuki <koshigoe@feedforce.jp> - 2.5.1
 - Update ruby version to 2.5.1


### PR DESCRIPTION
## Why

Fixed https://github.com/feedforce/ruby-rpm/issues/58

Ruby 2.4.4 released!

* [Ruby 2.4.4 リリース](https://www.ruby-lang.org/ja/news/2018/03/28/ruby-2-4-4-released/)

## How

* Create `ruby-2.4` branch from `master`
* Update a spec file
* Change release branch in CircleCI

## How to check operation

### CentOS 6

1. Run CentOS 6 using Docker

    ```
    $ docker run --rm -it centos:6
    ```

1. Install Ruby 2.4.4 with rpm file of CircleCI artifacts

    ```
    [root@0e56bc331638 /]# yum install -y libyaml
    [root@0e56bc331638 /]# rpm -i https://210-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.4.4-1.el6.x86_64.rpm

    ```

1. Run Ruby and check Ruby version

    ```
    [root@0e56bc331638 /]# ruby -e 'puts RUBY_VERSION'
    2.4.4
    ```

### CentOS 7

1. Run CentOS 7 using Docker

    ```
    $ docker run --rm -it centos:7
    ```

1. Install Ruby 2.4.4 with rpm file of CircleCI artifacts

    ```
    [root@978bcc3c91f8 /]# yum install -y libyaml openssl
    [root@978bcc3c91f8 /]# rpm -i https://209-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.4.4-1.el7.centos.x86_64.rpm
    ```

1. Run Ruby and check Ruby version

    ```
    [root@978bcc3c91f8 /]# ruby -e 'puts RUBY_VERSION'
    2.4.4
    ```