### PR TITLE
Bump up Ruby version to 2.5.2

### DIFF
--- a/ruby.spec
+++ b/ruby.spec
@@ -1,4 +1,4 @@
-%define rubyver         2.5.1
+%define rubyver         2.5.2
 
 Name:           ruby
 Version:        %{rubyver}
@@ -67,6 +67,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
+
+* Thu Oct 18 2018 Masataka Suzuki <koshigoe@feedforce.jp> - 2.5.2
+- Update ruby version to 2.5.2
 
 * Thu Mar 29 2018 Masataka Suzuki <koshigoe@feedforce.jp> - 2.5.1
 - Update ruby version to 2.5.1


### PR DESCRIPTION
Blocker
----

- [x] #62


Why
----

- [Ruby 2.5.2 Released](https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-5-2-released/)


How
----

- [x] Update SPEC file


Verify
----

- [x] Install RPMs
   - CentOS 6: https://235-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.5.2-1.el6.x86_64.rpm
   - CentOS 7: https://234-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.5.2-1.el7.x86_64.rpm
- [x] Run Ruby 2.5.2

### CentOS 6

```
[mac]% docker pull centos:6
[mac]% docker run --rm -it centos:6 sh

# yum install -y libyaml
# rpm -i https://235-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.5.2-1.el6.x86_64.rpm
# ruby -v -e 'puts File.read("/etc/centos-release")'
ruby 2.5.2p104 (2018-10-18 revision 65133) [x86_64-linux-gnu]
CentOS release 6.10 (Final)
```

### CentOS 7

```
[mac]% docker pull centos:7
[mac]% docker run --rm -it centos:7 sh

# yum install -y libyaml openssl
# rpm -ivh https://234-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.5.2-1.el7.x86_64.rpm
# ruby -v -e 'puts File.read("/etc/centos-release")'
ruby 2.5.2p104 (2018-10-18 revision 65133) [x86_64-linux]
CentOS Linux release 7.5.1804 (Core)
```