### PR TITLE
Add Ruby to CentOS 6 image to compile Ruby

### DIFF
--- a/Dockerfile-6
+++ b/Dockerfile-6
@@ -8,6 +8,9 @@ RUN yum install -y rpm-build tar
 # ruby depends
 RUN yum -y install readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel libyaml-devel libffi-devel zlib-devel
 
+# install ruby to compile ruby: https://bugs.ruby-lang.org/issues/14409
+RUN rpm -ivh https://github.com/feedforce/ruby-rpm/releases/download/2.5.1/ruby-2.5.1-1.el6.x86_64.rpm
+
 # rpmbuild command recommends to use `builder:builder` as user:group.
 RUN useradd -u 1000 builder
 

--- a/Dockerfile-6
+++ b/Dockerfile-6
@@ -8,7 +8,7 @@ RUN yum install -y rpm-build tar
 # ruby depends
 RUN yum -y install readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel libyaml-devel libffi-devel zlib-devel
 
-# install ruby to compile ruby: https://bugs.ruby-lang.org/issues/14409
+# [Workaround] install ruby to compile ruby: https://bugs.ruby-lang.org/issues/14409
 RUN rpm -ivh https://github.com/feedforce/ruby-rpm/releases/download/2.5.1/ruby-2.5.1-1.el6.x86_64.rpm
 
 # rpmbuild command recommends to use `builder:builder` as user:group.


### PR DESCRIPTION
The `configure` requires Ruby.
https://bugs.ruby-lang.org/issues/14409

I could not compile Ruby 2.5.2 using CentOS 6 image.
https://circleci.com/gh/feedforce/ruby-rpm/224