### PR TITLE
[Workaround] Use CentOS 7.4 to build RPM

### DIFF
--- a/Dockerfile-7
+++ b/Dockerfile-7
@@ -1,8 +1,7 @@
-FROM centos:7
+FROM centos:7.4.1708
 MAINTAINER feedforce Inc.
 
 # setup
-RUN yum update -y
 RUN yum install -y rpm-build tar make
 
 # ruby depends


### PR DESCRIPTION
Why
----

Expect `*.el7.centos.*.rpm`.

### CentOS 7.4

- ruby-2.5.2-1.el7.centos.src.rpm
- ruby-2.5.2-1.el7.centos.x86_64.rpm
- ruby-debuginfo-2.5.2-1.el7.centos.x86_64.rpm

### CentOS 7.5

- ruby-2.5.2-1.el7.src.rpm
- ruby-2.5.2-1.el7.x86_64.rpm
- ruby-debuginfo-2.5.2-1.el7.x86_64.rpm


How
----

- [x] Change base Docker image to `centos:7.4.1708`
- [x] Don't run `yum update`


Verify
----

- [x] Check file name of RPMs

```
[mac]% docker build -t feedforce/ruby-rpm:centos7 -f Dockerfile-7 .
[mac]% docker run -v ./:/home/builder/ruby-rpm --rm -it feedforce/ruby-rpm:centos7

$ su - builder
$ cd /home/builder/rpmbuild
$ cp ~/ruby-rpm/ruby.spec ./SPECS/
$ cd ./SOURCES
$ curl -LO https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.gz
$ rpmbuild -ba ../SPECS/ruby.spec
...
$ find ../ -name "*.rpm"
../SRPMS/ruby-2.5.2-1.el7.centos.src.rpm
../RPMS/x86_64/ruby-debuginfo-2.5.2-1.el7.centos.x86_64.rpm
../RPMS/x86_64/ruby-2.5.2-1.el7.centos.x86_64.rpm
```