### PR TITLE
Bump up Ruby version to 2.4.5

### DIFF
--- a/ruby.spec
+++ b/ruby.spec
@@ -1,4 +1,4 @@
-%define rubyver         2.4.4
+%define rubyver         2.4.5
 
 Name:           ruby
 Version:        %{rubyver}
@@ -67,6 +67,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/*
 
 %changelog
+* Thu Oct 18 2018 Tsubasa Takayama <t-takayama@feedforce.jp> - 2.4.5
+- Update ruby version to 2.4.5
 
 * Wed Apr 18 2018 Tsubasa Takayama <t-takayama@feedforce.jp> - 2.4.4
 - Update ruby version to 2.4.4


### PR DESCRIPTION
Why
----

- [Ruby 2\.4\.5 Released](https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-4-5-released/)

How
----

- [x] Update SPEC file

Verify
----

- [x] Install RPMs
   - CentOS 6: https://250-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.4.5-1.el6.x86_64.rpm
   - CentOS 7: https://251-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.4.5-1.el7.centos.x86_64.rpm
- [x] Run Ruby 2.4.5

### CentOS 6

```
[mac]% docker pull centos:6
[mac]% docker run --rm -it centos:6 sh

# yum install -y libyaml
# rpm -ivh https://250-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.4.5-1.el6.x86_64.rpm
# ruby -v -e 'puts File.read("/etc/centos-release")'
ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-linux-gnu]
CentOS release 6.10 (Final)
```

### CentOS 7

```
[mac]% docker pull centos:7
[mac]% docker run --rm -it centos:7 sh

# yum install -y libyaml openssl
# rpm -ivh https://251-25909051-gh.circle-artifacts.com/0/ruby-rpm/ruby-2.4.5-1.el7.centos.x86_64.rpm
# ruby -v -e 'puts File.read("/etc/centos-release")'
ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-linux]
CentOS Linux release 7.5.1804 (Core)
```