### PR TITLE
Remove workaround from Dockerfile

### DIFF
--- a/Dockerfile-6
+++ b/Dockerfile-6
@@ -8,9 +8,6 @@ RUN yum install -y rpm-build tar
 # ruby depends
 RUN yum -y install readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel libyaml-devel libffi-devel zlib-devel
 
-# [Workaround] install ruby to compile ruby: https://bugs.ruby-lang.org/issues/14409
-RUN rpm -ivh https://github.com/feedforce/ruby-rpm/releases/download/2.5.1/ruby-2.5.1-1.el6.x86_64.rpm
-
 # rpmbuild command recommends to use `builder:builder` as user:group.
 RUN useradd -u 1000 builder
 


### PR DESCRIPTION
revert #62

Fixed bug by Ruby 2.5.3

- [Ruby 2.5.3 Released](https://www.ruby-lang.org/en/news/2018/10/18/ruby-2-5-3-released/)