### PR TITLE
PR 作成時の Ruby のバージョン比較を前方一致から完全一致に修正

### DIFF
--- a/.circleci/update-spec.sh
+++ b/.circleci/update-spec.sh
@@ -17,7 +17,7 @@ do
         continue
     fi
 
-    if grep -q "^Version: ${ruby_x_y_z_version}" $f
+    if grep -q "^Version: ${ruby_x_y_z_version}\$" $f
     then
         echo "SPEC file is up to date."
         continue


### PR DESCRIPTION
クリスマスプレゼント([2.6.0](https://www.ruby-lang.org/ja/news/2018/12/25/ruby-2-6-0-released/))に失敗していた。