### PR TITLE
Ruby 2.6.0 のコンパイルに失敗したので `CFLAGS` に `-std=c99` を追加する

### DIFF
--- a/ruby-2.6.spec
+++ b/ruby-2.6.spec
@@ -36,7 +36,7 @@ straight-forward, and extensible.
 %setup -n ruby-%{version}
 
 %build
-export CFLAGS="$RPM_OPT_FLAGS -Wall -fno-strict-aliasing"
+export CFLAGS="$RPM_OPT_FLAGS -Wall -fno-strict-aliasing -std=c99"
 
 %configure \
   --enable-shared \


### PR DESCRIPTION
自動 PR 作成は動かせたが、コンパイルエラーでビルド失敗(#71)。

```
addr2line.c:1210: error: 'for' loop initial declarations are only allowed in C99 mode
addr2line.c:1210: note: use option -std=c99 or -std=gnu99 to compile your code
```

- [エラーログ](https://gist.github.com/koshigoe/9e967b6265a34075be14f6c63f1987aa)

<details>
<summary>コンパイルエラー抜粋</summary>

```
...
---
Configuration summary for ruby version 2.6.0

   * Installation prefix: /usr
   * exec prefix:         /usr
   * arch:                x86_64-linux-gnu
   * site arch:           ${arch}
   * RUBY_BASE_NAME:      ruby
   * enable shared:       yes
   * ruby lib prefix:     ${libdir}/${RUBY_BASE_NAME}
   * site libraries path: ${rubylibprefix}/${sitearch}
   * vendor path:         ${rubylibprefix}/vendor_ruby
   * target OS:           linux-gnu
   * compiler:            gcc
   * with pthread:        yes
   * enable shared libs:  yes
   * dynamic library ext: so
   * CFLAGS:              ${optflags} ${debugflags} ${warnflags}
   * LDFLAGS:             -L. -fstack-protector -rdynamic \
                          -Wl,-export-dynamic
   * optflags:            -O3
   * debugflags:          -ggdb3
   * warnflags:           -Wall -Wextra -Wdeclaration-after-statement \
                          -Wdeprecated-declarations \
                          -Wimplicit-function-declaration -Wimplicit-int \
                          -Wpointer-arith -Wwrite-strings \
                          -Wmissing-noreturn -Wno-cast-function-type \
                          -Wno-constant-logical-operand -Wno-long-long \
                          -Wno-missing-field-initializers \
                          -Wno-overlength-strings \
                          -Wno-packed-bitfield-compat \
                          -Wno-parentheses-equality -Wno-self-assign \
                          -Wno-tautological-compare -Wno-unused-parameter \
                          -Wno-unused-value -Wunused-variable
   * strip command:       strip -S -x
   * install doc:         yes
   * JIT support:         yes
   * man page type:       doc

---
+ make -j16
	BASERUBY = echo executable host ruby is required.  use --with-baseruby option.; false
	CC = gcc
	LD = ld
	LDSHARED = gcc -shared
	CFLAGS = -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -mtune=generic -Wall -fno-strict-aliasing -fPIC -m64
	XCFLAGS = -D_FORTIFY_SOURCE=2 -fstack-protector -fno-strict-overflow -fvisibility=hidden -DRUBY_EXPORT -DCANONICALIZATION_FOR_MATHN
	CPPFLAGS =   -I. -I.ext/include/x86_64-linux-gnu -I./include -I. -I./enc/unicode/11.0.0 
	DLDFLAGS = -Wl,-soname,libruby.so.2.6  -fstack-protector  -m64
	SOLIBS = -lpthread -lrt -lrt -lrt -ldl -lcrypt -lm 
	LANG = C
	LC_ALL = 
	LC_CTYPE = 
gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
...
make: *** [addr2line.o] Error 1
make: *** Waiting for unfinished jobs....
dln.c:1247: warning: expected [error|warning|ignored] after '#pragma GCC diagnostic'
dln.c:1249: warning: unknown option after '#pragma GCC diagnostic' kind
dln.c:1257: warning: expected [error|warning|ignored] after '#pragma GCC diagnostic'
vm_trace.c: In function 'rb_suppress_tracing':
vm_trace.c:434: warning: '_ec' may be used uninitialized in this function
vm_trace.c: In function 'exec_hooks_protected':
vm_trace.c:349: warning: '_ec' may be used uninitialized in this function
prelude.c:204: warning: expected [error|warning|ignored] after '#pragma GCC diagnostic'
prelude.c:234: warning: expected [error|warning|ignored] after '#pragma GCC diagnostic'
thread.c: In function 'thread_start_func_2':
thread.c:723: warning: '_ec' may be used uninitialized in this function
In file included from thread.c:354:
thread_pthread.c: In function 'rb_sigwait_sleep':
thread_pthread.c:2043: warning: 'end' may be used uninitialized in this function
thread.c: In function 'rb_thread_s_handle_interrupt':
thread.c:2001: warning: '_ec' may be used uninitialized in this function
thread.c: In function 'rb_thread_terminate_all':
thread.c:568: warning: '_ec' may be used uninitialized in this function
In file included from vm.c:328:
vm_eval.c: In function 'rb_eval_cmd':
vm_eval.c:1509: warning: 'current_safe_level' may be used uninitialized in this function
vm_eval.c:1516: warning: '_ec' may be used uninitialized in this function
error: Bad exit status from /var/tmp/rpm-tmp.DdlhFv (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.DdlhFv (%build)
Exited with code 1
```

</details>