### PR TITLE
Add `AutoReqProv: no` to avoid "Requires: /usr/local/bin/ruby"

### DIFF
--- a/ruby-2.7.spec
+++ b/ruby-2.7.spec
@@ -4,6 +4,7 @@ Release: 1%{?dist}
 License: Ruby License/GPL - see COPYING
 URL: http://www.ruby-lang.org/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+AutoReqProv: no
 Requires: readline ncurses gdbm glibc openssl libyaml libffi zlib
 BuildRequires: readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel make libyaml-devel libffi-devel zlib-devel
 Source0: https://cache.ruby-lang.org/pub/ruby/ruby-%{version}.tar.gz


### PR DESCRIPTION
<details>
<summary>Before</summary>

```
% docker run -u builder -v (pwd):/home/builder/ruby-rpm --rm -it feedforce/ruby-rpm:centos7 bash

$ cp ~/ruby-rpm/ruby-2.7.spec ~/rpmbuild/SPECS/
$ cd ~/rpmbuild/SOURCES
$ curl -LO https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz
$ rpmbuild -ba --noclean ~/rpmbuild/SPECS/ruby-2.7.spec
...
$ rpm -qRp ~/rpmbuild/RPMS/x86_64/ruby-2.7.0-1.el7.centos.x86_64.rpm
/usr/bin/env
/usr/bin/pkg-config
/usr/bin/ruby
/usr/local/bin/ruby
gdbm
glibc
ld-linux-x86-64.so.2()(64bit)
ld-linux-x86-64.so.2(GLIBC_2.2.5)(64bit)
libanl.so.1()(64bit)
libanl.so.1(GLIBC_2.2.5)(64bit)
libc.so.6()(64bit)
libc.so.6(GLIBC_2.10)(64bit)
libc.so.6(GLIBC_2.14)(64bit)
libc.so.6(GLIBC_2.17)(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.3)(64bit)
libc.so.6(GLIBC_2.3.4)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libc.so.6(GLIBC_2.6)(64bit)
libc.so.6(GLIBC_2.7)(64bit)
libc.so.6(GLIBC_2.8)(64bit)
libc.so.6(GLIBC_2.9)(64bit)
libcrypt.so.1()(64bit)
libcrypt.so.1(GLIBC_2.2.5)(64bit)
libcrypto.so.10()(64bit)
libcrypto.so.10(OPENSSL_1.0.1_EC)(64bit)
libcrypto.so.10(OPENSSL_1.0.2)(64bit)
libcrypto.so.10(libcrypto.so.10)(64bit)
libdl.so.2()(64bit)
libdl.so.2(GLIBC_2.2.5)(64bit)
libffi
libffi.so.6()(64bit)
libgdbm.so.4()(64bit)
libgdbm_compat.so.4()(64bit)
libm.so.6()(64bit)
libm.so.6(GLIBC_2.2.5)(64bit)
libncurses.so.5()(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.12)(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpthread.so.0(GLIBC_2.3.2)(64bit)
libpthread.so.0(GLIBC_2.3.3)(64bit)
libreadline.so.6()(64bit)
librt.so.1()(64bit)
librt.so.1(GLIBC_2.2.5)(64bit)
librt.so.1(GLIBC_2.3.3)(64bit)
libruby.so.2.7()(64bit)
libssl.so.10()(64bit)
libssl.so.10(libssl.so.10)(64bit)
libtinfo.so.5()(64bit)
libutil.so.1()(64bit)
libyaml
libyaml-0.so.2()(64bit)
libz.so.1()(64bit)
libz.so.1(ZLIB_1.2.2)(64bit)
ncurses
openssl
readline
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rtld(GNU_HASH)
zlib
rpmlib(PayloadIsXz) <= 5.2-1
```

</details>

<details>
<summary>After</summary>

```
% docker run -u builder -v (pwd):/home/builder/ruby-rpm --rm -it feedforce/ruby-rpm:centos7 bash

$ cp ~/ruby-rpm/ruby-2.7.spec ~/rpmbuild/SPECS/
$ cd ~/rpmbuild/SOURCES
$ curl -LO https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz
$ rpmbuild -ba --noclean ~/rpmbuild/SPECS/ruby-2.7.spec
...
$ rpm -qRp ~/rpmbuild/RPMS/x86_64/ruby-2.7.0-1.el7.centos.x86_64.rpm
readline
ncurses
gdbm
glibc
openssl
libyaml
libffi
zlib
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1
```

</details>