### PR TITLE
Refactor CircleCI configuration using matrix jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,77 +134,27 @@ workflows:
   version: 2
   default:
     jobs:
-      # Ruby 2.5
       - build:
-          name: ruby-2.5-centos7-build
+          name: ruby-<< matrix.version >>-centos7-build
           image: "feedforce/ruby-rpm:centos7"
-          version: "2.5"
-          filters:
-            branches:
-              only:
-                - master
-                - /ruby-2\.5\..+/
+          matrix:
+            parameters:
+              version: ["2.5", "2.6", "2.7"]
       - test:
-          name: ruby-2.5-centos7-test
+          name: ruby-<< matrix.version >>-centos7-test
           image: centos:7
-          version: "2.5"
+          matrix:
+            parameters:
+              version: ["2.5", "2.6", "2.7"]
           requires:
-            - ruby-2.5-centos7-build
+            - ruby-<< matrix.version >>-centos7-build
       - deploy:
-          name: ruby-2.5-deploy
-          version: "2.5"
+          name: ruby-<< matrix.version >>-deploy
+          matrix:
+            parameters:
+              version: ["2.5", "2.6", "2.7"]
           requires:
-            - ruby-2.5-centos7-test
-          filters:
-            branches:
-              only:
-                - master
-      # Ruby 2.6
-      - build:
-          name: ruby-2.6-centos7-build
-          image: "feedforce/ruby-rpm:centos7"
-          version: "2.6"
-          filters:
-            branches:
-              only:
-                - master
-                - /ruby-2\.6\..+/
-      - test:
-          name: ruby-2.6-centos7-test
-          image: centos:7
-          version: "2.6"
-          requires:
-            - ruby-2.6-centos7-build
-      - deploy:
-          name: ruby-2.6-deploy
-          version: "2.6"
-          requires:
-            - ruby-2.6-centos7-test
-          filters:
-            branches:
-              only:
-                - master
-      # Ruby 2.7
-      - build:
-          name: ruby-2.7-centos7-build
-          image: "feedforce/ruby-rpm:centos7"
-          version: "2.7"
-          filters:
-            branches:
-              only:
-                - master
-                - /ruby-2\.7\..+/
-      - test:
-          name: ruby-2.7-centos7-test
-          image: centos:7
-          version: "2.7"
-          requires:
-            - ruby-2.7-centos7-build
-      - deploy:
-          name: ruby-2.7-deploy
-          version: "2.7"
-          requires:
-            - ruby-2.7-centos7-test
+            - ruby-<< matrix.version >>-centos7-test
           filters:
             branches:
               only:


### PR DESCRIPTION
CircleCI の matrix jobs を使えば `.circleci/config.yml` の記述を短縮できるため、やってみた。

* blog: [Matrix jobs - Matrix builds | CircleCI](https://circleci.com/blog/circleci-matrix-jobs/)
* document: [Example of using an executor declared in config.yml with matrix jobs. | Reusable Config Reference Guide - CircleCI](https://circleci.com/docs/2.0/reusing-config/#example-of-using-an-executor-declared-in-configyml-with-matrix-jobs)
* reference: [matrix (requires version: 2.1) | Configuring CircleCI - CircleCI](https://circleci.com/docs/2.0/configuration-reference/?section=reference#matrix-requires-version-21)

## 動作確認

* [x] CI が通っていること
* [x] Ruby 2.5, 2.6, 2.7 でそれぞれ CI が動いていること

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/10208211/108816613-d2ddf480-75f9-11eb-9c82-2d04a9f19c6d.png">

* [x] ブランチ名のフィルタリング以外で変更前後の差分がないこと

```
$ git switch master
$ git pull origin master
$ circleci config process .circleci/config.yml > before
$ git switch refactor-circleci-config-using-matrix-jobs
$ circleci config process .circleci/config.yml > after
$ diff before after
```

<details>
<summary>Show diff</summary>

```diff
--- before      2021-02-23 17:10:34.000000000 +0900
+++ after       2021-02-23 17:11:14.000000000 +0900
@@ -151,15 +151,18 @@
   version: 2
   default:
     jobs:
-    - ruby-2.5-centos7-build:
-        filters:
-          branches:
-            only:
-            - master
-            - /ruby-2\.5\..+/
+    - ruby-2.5-centos7-build
+    - ruby-2.6-centos7-build
+    - ruby-2.7-centos7-build
     - ruby-2.5-centos7-test:
         requires:
         - ruby-2.5-centos7-build
+    - ruby-2.6-centos7-test:
+        requires:
+        - ruby-2.6-centos7-build
+    - ruby-2.7-centos7-test:
+        requires:
+        - ruby-2.7-centos7-build
     - ruby-2.5-deploy:
         filters:
           branches:
@@ -167,15 +170,6 @@
             - master
         requires:
         - ruby-2.5-centos7-test
-    - ruby-2.6-centos7-build:
-        filters:
-          branches:
-            only:
-            - master
-            - /ruby-2\.6\..+/
-    - ruby-2.6-centos7-test:
-        requires:
-        - ruby-2.6-centos7-build
     - ruby-2.6-deploy:
         filters:
           branches:
@@ -183,15 +177,6 @@
             - master
         requires:
         - ruby-2.6-centos7-test
-    - ruby-2.7-centos7-build:
-        filters:
-          branches:
-            only:
-            - master
-            - /ruby-2\.7\..+/
-    - ruby-2.7-centos7-test:
-        requires:
-        - ruby-2.7-centos7-build
     - ruby-2.7-deploy:
         filters:
           branches:
@@ -347,77 +332,27 @@
 #   version: 2
 #   default:
 #     jobs:
-#       # Ruby 2.5
-#       - build:
-#           name: ruby-2.5-centos7-build
-#           image: \"feedforce/ruby-rpm:centos7\"
-#           version: \"2.5\"
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#                 - /ruby-2\\.5\\..+/
-#       - test:
-#           name: ruby-2.5-centos7-test
-#           image: centos:7
-#           version: \"2.5\"
-#           requires:
-#             - ruby-2.5-centos7-build
-#       - deploy:
-#           name: ruby-2.5-deploy
-#           version: \"2.5\"
-#           requires:
-#             - ruby-2.5-centos7-test
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#       # Ruby 2.6
 #       - build:
-#           name: ruby-2.6-centos7-build
+#           name: ruby-<< matrix.version >>-centos7-build
 #           image: \"feedforce/ruby-rpm:centos7\"
-#           version: \"2.6\"
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#                 - /ruby-2\\.6\\..+/
-#       - test:
-#           name: ruby-2.6-centos7-test
-#           image: centos:7
-#           version: \"2.6\"
-#           requires:
-#             - ruby-2.6-centos7-build
-#       - deploy:
-#           name: ruby-2.6-deploy
-#           version: \"2.6\"
-#           requires:
-#             - ruby-2.6-centos7-test
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#       # Ruby 2.7
-#       - build:
-#           name: ruby-2.7-centos7-build
-#           image: \"feedforce/ruby-rpm:centos7\"
-#           version: \"2.7\"
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#                 - /ruby-2\\.7\\..+/
+#           matrix:
+#             parameters:
+#               version: [\"2.5\", \"2.6\", \"2.7\"]
 #       - test:
-#           name: ruby-2.7-centos7-test
+#           name: ruby-<< matrix.version >>-centos7-test
 #           image: centos:7
-#           version: \"2.7\"
+#           matrix:
+#             parameters:
+#               version: [\"2.5\", \"2.6\", \"2.7\"]
 #           requires:
-#             - ruby-2.7-centos7-build
+#             - ruby-<< matrix.version >>-centos7-build
 #       - deploy:
-#           name: ruby-2.7-deploy
-#           version: \"2.7\"
+#           name: ruby-<< matrix.version >>-deploy
+#           matrix:
+#             parameters:
+#               version: [\"2.5\", \"2.6\", \"2.7\"]
 #           requires:
-#             - ruby-2.7-centos7-test
+#             - ruby-<< matrix.version >>-centos7-test
 #           filters:
 #             branches:
 #               only:
```

</details>