### PR TITLE
Drop support for CentOS 6 (Fixup PR #97)

### DIFF
--- a/.circleci/github-release.sh
+++ b/.circleci/github-release.sh
@@ -72,18 +72,6 @@ for i in *.el7.centos.x86_64.rpm *.el7.centos.src.rpm; do
   upload_rpm $i
 done
 
-cat <<EOS >> description.md
-
-Build on CentOS 6
-
-EOS
-
-# CentOS 6
-for i in *.el6.x86_64.rpm *.el6.src.rpm; do
-  print_rpm_markdown $i >> description.md
-  upload_rpm $i
-done
-
 #
 # Make the release note to complete!
 #


### PR DESCRIPTION
https://github.com/feedforce/ruby-rpm/pull/97 での `.circleci/github-release.sh` の修正漏れを対応。

https://github.com/feedforce/ruby-rpm/pull/99 をマージ後、master の CircleCI が落ちていた。

> ```
> + /home/circleci/bin/github-release upload --user feedforce --repo ruby-rpm --tag 2.5.9 --name ruby-2.5.9-1.el7.centos.src.rpm --file ruby-2.5.9-1.el7.centos.src.rpm
> + cat
> + print_rpm_markdown *.el6.x86_64.rpm
> + RPM_FILE=*.el6.x86_64.rpm
> + openssl sha256 *.el6.x86_64.rpm
> + awk {print $2}
> *.el6.x86_64.rpm: No such file or directory
> + cat
> + upload_rpm *.el6.x86_64.rpm
> + RPM_FILE=*.el6.x86_64.rpm
> + /home/circleci/bin/github-release upload --user feedforce --repo ruby-rpm --tag 2.5.9 --name *.el6.x86_64.rpm --file *.el6.x86_64.rpm
> Error: open *.el6.x86_64.rpm: no such file or directory
> ...
> ```
> 
> https://app.circleci.com/pipelines/github/feedforce/ruby-rpm/8960/workflows/64c66918-57af-41e8-89ce-da8c7c8f1925/jobs/21126

その他に漏れがないことも確認。

```
$ git switch master
$ git pull origin master
$ git grep el6
.circleci/github-release.sh:for i in *.el6.x86_64.rpm *.el6.src.rpm; do
```