### PR TITLE
Faster docker build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ executors:
     machine:
       image: ubuntu-2004:202104-01
     environment:
-      DOCKER_BUILD_KIT: 1
+      DOCKER_BUILDKIT: 1
 
   arm64:
     machine:
       image: ubuntu-2004:202104-01
     environment:
-      DOCKER_BUILD_KIT: 1
+      DOCKER_BUILDKIT: 1
     resource_class: arm.medium
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ docker buildx build \
     -t feedforce/ruby-rpm:centos7 \
     -f Dockerfile-7 \
     --target base \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
     --platform=linux/amd64,linux/arm64 \
     --push \
     .

--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ The Docker images are hosted at [Docker Hub](https://hub.docker.com/).
 
 - For CentOS 7: [`feedforce/ruby-rpm:centos7`](https://hub.docker.com/r/feedforce/ruby-rpm/)
 
-## How to build Docker image
+## How to build and push Docker image
 
 ### Manually
 
 You can also build Docker images manually.
 
 ```
-$ docker build -t feedforce/ruby-rpm:centos7 -f Dockerfile-7 --target base .
-```
-
-Push to Docker Hub if necessary.
-
-```
 $ docker login
-$ docker push feedforce/ruby-rpm:centos7
+$ docker buildx create --use
+$ docker buildx build \
+    -t feedforce/ruby-rpm:centos7 \
+    -f Dockerfile-7 \
+    --target base \
+    --platform=linux/amd64,linux/arm64 \
+    --push \
+    .
 ```


### PR DESCRIPTION
## Why?

https://github.com/feedforce/ruby-rpm/pull/106 で変更した CirlcleCI のビルド周りで docker build 時のキャッシュが効いていなかった。

## How?

* Docker Hub に linux/arm64 のイメージも Push するように README を修正
* Docker Hub に Push するイメージのみ、ビルド時に BUILDKIT_INLINE_CACHE を有効化
    * buildkit では `--cache-from` で使うイメージを外部から Pull する場合、`BUILDKIT_INLINE_CACHE` が有効化されていないとキャッシュが使われないため ([参考](https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources))
    * Docker Hub に Push しない CI 内でのみ使うイメージは `BUILDKIT_INLINE_CACHE` を有効にしなくてもキャッシュが効く
* Builtkit を有効化するための環境変数名が間違っていたので修正

## How to check

### Before

master でのビルド: https://app.circleci.com/pipelines/github/feedforce/ruby-rpm/10874/workflows/ebe4be3d-484d-4c2b-a592-3e1261737e70

![image](https://user-images.githubusercontent.com/10208211/123022883-7062fc80-d411-11eb-928c-2f60eec7449a.png)

### After

この PR のビルド: https://app.circleci.com/pipelines/github/feedforce/ruby-rpm/10877/workflows/356d41d8-e19e-479c-a18f-0113b85987b4

![image](https://user-images.githubusercontent.com/10208211/123022992-97213300-d411-11eb-9d79-d2a63cb87fba.png)

builder target の docker build 時に base target の部分 (Docker Hub のイメージ) はキャッシュが効いていることを確認。

> ```
> #4 importing cache manifest from feedforce/ruby-rpm:centos7
> #4 sha256:a2f38ca0d1842cdf14bead3973c6d362137272c12dd1463607d1e8a6da40e827
> #4 DONE 0.2s
> 
> #5 [base 2/3] RUN yum install -y rpm-build tar make
> #5 sha256:95bd0f3f6b693064e6eb68c5cdaf671151fb16dc7e94b0d6d61bf3a4955a8ac6
> #5 CACHED
> 
> #6 [base 3/3] RUN yum -y install readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel libyaml-devel libffi-devel zlib-devel
> #6 sha256:8fd2ac6b340a4ee1e33992b44de77a5661e511f71c6c8b0b2d4130e4889ba0d0
> #6 pulling sha256:6717b8ec66cd6add0272c6391165585613c31314a43ff77d9751b53010e531ec
> #6 pulling sha256:34b4a97d99ac567e2eb1d7022cf0ac23c6810cc52f57c2787a6239d15aacc61d
> #6 pulling sha256:57503d10a59ae3d930399e6165813c753ce89b5a6ed005f6857aa11d0263662d
> #6 ...
> 
> #13 [internal] load build context
> #13 sha256:1f5cbb262aa871e78e87d63034e4d1ca4d754d94117bc0b58a2bb7a5675845ae
> #13 transferring context: 299.39kB done
> #13 DONE 0.1s
> 
> #6 [base 3/3] RUN yum -y install readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel libyaml-devel libffi-devel zlib-devel
> #6 sha256:8fd2ac6b340a4ee1e33992b44de77a5661e511f71c6c8b0b2d4130e4889ba0d0
> #6 pulling sha256:57503d10a59ae3d930399e6165813c753ce89b5a6ed005f6857aa11d0263662d 0.8s done
> #6 pulling sha256:34b4a97d99ac567e2eb1d7022cf0ac23c6810cc52f57c2787a6239d15aacc61d 0.8s done
> #6 pulling sha256:6717b8ec66cd6add0272c6391165585613c31314a43ff77d9751b53010e531ec 1.5s done
> #6 CACHED
> ```

tester target の docker build 時も builder target の部分は (CircleCI 内で使っているイメージ) はキャッシュが効いていることを確認。

> ```
> #18 importing cache manifest from feedforce/ruby-rpm:3.0-builder
> #18 sha256:3b1e623cdd8a05ba44add131150db29e351c10fa6383e40ad07f14454008abb0
> #18 DONE 0.0s
> 
> #4 [base 1/3] FROM docker.io/library/centos:7@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e
> #4 sha256:f05ea07dac8bd412b037a6780ecf0ca7353ae70594db3602b3c7a13699393615
> #4 DONE 0.0s
> 
> #5 [base 2/3] RUN yum install -y rpm-build tar make
> #5 sha256:95bd0f3f6b693064e6eb68c5cdaf671151fb16dc7e94b0d6d61bf3a4955a8ac6
> #5 CACHED
> 
> #6 [base 3/3] RUN yum -y install readline-devel ncurses-devel gdbm-devel glibc-devel gcc openssl-devel libyaml-devel libffi-devel zlib-devel
> #6 sha256:8fd2ac6b340a4ee1e33992b44de77a5661e511f71c6c8b0b2d4130e4889ba0d0
> #6 CACHED
> 
> #13 [internal] load build context
> #13 sha256:8e855c4e9d3fb6a27400276763e896ce3b9d3fc87e635e5e0ed2885733db6972
> #13 transferring context: 2.38kB done
> #13 DONE 0.0s
> 
> #7 [builder 1/8] RUN useradd -u 1000 builder
> #7 sha256:959a67732e8dc24bf39840d99697ab12ae49da09c7ad5b131f413eb1ababd0dc
> #7 CACHED
> 
> #14 [builder 7/8] COPY . /home/builder/ruby-rpm/
> #14 sha256:9a33ba8f02e3a5e58e6ac45ff937f0b845e75b241f6d0e27d4cba30228082c6d
> #14 CACHED
> 
> #8 [builder 2/8] RUN mkdir -p /home/builder/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
> #8 sha256:471640448d8ed4b2f18ed0adb30ed456df1171d38c9aae913d758b6fc74fc689
> #8 CACHED
> 
> #12 [builder 6/8] WORKDIR /home/builder/ruby-rpm
> #12 sha256:85d7059aef24cb3efaa5b8eeb41e97da248102f9f8df8250666bca3cd56d077f
> #12 CACHED
> 
> #11 [builder 5/8] RUN chown -R builder:builder /home/builder/ruby-rpm
> #11 sha256:00346fa2e9e346490f424bfe3d409900472ac4cdcce17a175fa4bdfe4d851789
> #11 CACHED
> 
> #9 [builder 3/8] RUN mkdir -p /home/builder/ruby-rpm
> #9 sha256:8acd24ed8e1e778a38b5f52575d87385750ec7f6647a12630bd99361d26e7f5b
> #9 CACHED
> 
> #10 [builder 4/8] RUN chown -R builder:builder /home/builder/rpmbuild
> #10 sha256:048d68c391431c26b4d32dbb69fbfb2e3378f2323a0d104ad8050728a95e5fe0
> #10 CACHED
> 
> #15 [builder 8/8] RUN /home/builder/ruby-rpm/scripts/build-rpm.sh 3.0
> #15 sha256:474db759feaeeaa8af0af3128fc57f82b0ea7b30efe8d8ee85e7b4e80dc7e2d6
> #15 CACHED
> ```

ただし、https://github.com/feedforce/ruby-rpm/pull/106 以前のビルドよりは確実に遅くなっていた。
(3m 前後 → 5m ~ 6m)

https://github.com/feedforce/ruby-rpm/pull/105 のビルド: https://app.circleci.com/pipelines/github/feedforce/ruby-rpm/8993/workflows/a650e478-89cd-41b3-9a69-554a10e26cf5

![image](https://user-images.githubusercontent.com/10208211/123023260-0dbe3080-d412-11eb-97a4-665ac15d50af.png)

RPM ビルドの部分が遅くなっているため、machine executor に変えた関係か、Docker コンテナ内でビルドするように変えた関係でなんらかのオーバーヘッド、あるいはスペック低下が原因と思われる。

Docker イメージ側でどうにかできなさそうなので今回はこのままとする。