### PR TITLE
[Don't merge] Upload aarch64 RPM files for only latest releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,10 +188,6 @@ workflows:
           requires:
             - ruby-<< matrix.version >>-centos7-amd64-build-and-test
             - ruby-<< matrix.version >>-centos7-arm64-build-and-test
-          filters:
-            branches:
-              only:
-                - master
 
   continuous_update:
     triggers:

--- a/.circleci/github-release.sh
+++ b/.circleci/github-release.sh
@@ -4,11 +4,6 @@ set -xe
 
 RUBY_VERSION=$(grep '^Version: ' ruby-${1}.spec | awk '{ print $NF }')
 
-need_to_release() {
-	http_code=$(curl -sL -w "%{http_code}\\n" https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${RUBY_VERSION} -o /dev/null)
-	test $http_code = "404"
-}
-
 get_github_release() {
   version=v0.7.5
   wget https://github.com/meterup/github-release/releases/download/${version}/linux-amd64-github-release.bz2
@@ -18,25 +13,8 @@ get_github_release() {
   mv linux-amd64-github-release $HOME/bin/github-release
 }
 
-if ! need_to_release; then
-	echo "$CIRCLE_PROJECT_REPONAME $RUBY_VERSION has already released."
-	exit 0
-fi
-
 get_github_release
 cp $CIRCLE_ARTIFACTS/*.rpm .
-
-#
-# Create a release page
-#
-
-$HOME/bin/github-release release \
-  --user $CIRCLE_PROJECT_USERNAME \
-  --repo $CIRCLE_PROJECT_REPONAME \
-  --tag $RUBY_VERSION \
-  --name "Ruby-${RUBY_VERSION}" \
-  --description "not release" \
-  --target master
 
 #
 # Upload rpm files and build a release note
@@ -67,9 +45,15 @@ Build on CentOS 7
 EOS
 
 # CentOS 7
+
+# Upload RPM files only aarch64
+for i in *.el7.centos.aarch64.rpm; do
+  upload_rpm $i
+done
+
+# Prepare to edit description
 for i in *.el7.centos.*.rpm; do
   print_rpm_markdown $i >> description.md
-  upload_rpm $i
 done
 
 #


### PR DESCRIPTION
## Why?

https://github.com/feedforce/ruby-rpm/pull/106 で aarch64 向けの RPM ファイルをビルドするようにしたが、既存のリリースには適応されないため、この PR で対応する。

過去のリリース全てでアップロードするのは大変なため、以下の最新バージョンのみアップロードする。

* [3.0.1](https://github.com/feedforce/ruby-rpm/releases/tag/3.0.1)
* [2.7.3](https://github.com/feedforce/ruby-rpm/releases/tag/2.7.3)
* [2.6.7](https://github.com/feedforce/ruby-rpm/releases/tag/2.6.7)

:warning: この PR 内でリリースするため、マージはしない。

## How?

* aarch64 の RPM ファイルだけアップロードするようにスクリプトを変更
    * 既存のリリースに対して aarch64 の RPM ファイルだけアップロード
    * description は x86_64 の RPM ファイルの情報も含めたまま更新

## How to check

* [x] CircleCI の deploy Job が成功していること

    ![image](https://user-images.githubusercontent.com/10208211/123026115-9ccd4780-d416-11eb-80e7-78479a48cba0.png)

* [x] GitHub Releases に aarch64 の RPM ファイルがアップロードされていること

    ![image](https://user-images.githubusercontent.com/10208211/123026136-a656af80-d416-11eb-82c7-9b9f8b507809.png)

    ![image](https://user-images.githubusercontent.com/10208211/123026192-b9697f80-d416-11eb-9683-d113c0be8766.png)

    ![image](https://user-images.githubusercontent.com/10208211/123026180-b53d6200-d416-11eb-9c63-30516f6a449d.png)