### PR TITLE
デプロイ時のアップロードエラーを回避するための待機

### DIFF
--- a/.circleci/github-release.sh
+++ b/.circleci/github-release.sh
@@ -38,6 +38,9 @@ $HOME/bin/github-release release \
   --description "not release" \
   --target master
 
+# Wait a few seconds after create release to avoid to error `could not find the release corresponding to tag ...`.
+sleep 5
+
 #
 # Upload rpm files and build a release note
 #


### PR DESCRIPTION
Why
----

`github-release upload` で RPM ファイルをアップロードする際、以下のエラーで失敗するようになっていた。

> error: could not find the release corresponding to tag 2.7.6
> error: could not find the release corresponding to tag 3.0.4
> https://app.circleci.com/pipelines/github/feedforce/ruby-rpm/17957/workflows/1cd3d5c9-5e3b-4817-9dd4-69e0a948e451


How
----

- [x] `github-release release` と `github-release upload` の間に sleep を追加


Verify
----

- [x] [デプロイテスト](https://app.circleci.com/pipelines/github/feedforce/ruby-rpm/17961/workflows/c840df51-3d50-4f53-b358-4dd712ec7f00)
    - 成功を確認した後、リリースとタグを削除した
- [x] CI