### PR TITLE
Migrate container image from Docker Hub to ghcr.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
               -t feedforce/ruby-rpm:<< parameters.version >>-builder \
               -f Dockerfile-7 \
               --target builder \
-              --cache-from=feedforce/ruby-rpm:centos7 \
+              --cache-from=ghcr.io/feedforce/ruby-rpm:centos7 \
               --build-arg RUBY_X_Y_VERSION=<< parameters.version >> \
               --progress plain \
               .
@@ -94,7 +94,7 @@ jobs:
               -t feedforce/ruby-rpm:<< parameters.version >>-tester \
               -f Dockerfile-7 \
               --target tester \
-              --cache-from=feedforce/ruby-rpm:<< parameters.version >>-builder \
+              --cache-from=ghcr.io/feedforce/ruby-rpm:<< parameters.version >>-builder \
               --build-arg RUBY_X_Y_VERSION=<< parameters.version >> \
               --progress plain \
               .

--- a/README.md
+++ b/README.md
@@ -24,25 +24,20 @@ We create a Pull Request automatically using CircleCI.
 
 This project uses Docker to build RPMs.
 
-The Docker images are hosted at [Docker Hub](https://hub.docker.com/).
+The Docker images are hosted at [GitHub Container Registry (ghcr.io)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
-- For CentOS 7: [`feedforce/ruby-rpm:centos7`](https://hub.docker.com/r/feedforce/ruby-rpm/)
+- For CentOS 7: `ghcr.io/feedforce/ruby-rpm:centos7`
 
 ## How to build and push Docker image
 
+Build and push Docker image to ghcr.io from GitHub Actions.
+
 ### Manually
 
-You can also build Docker images manually.
+Currently, only manual execution using the workflow_dispatch event is supported.
 
-```
-$ docker login
-$ docker buildx create --use
-$ docker buildx build \
-    -t feedforce/ruby-rpm:centos7 \
-    -f Dockerfile-7 \
-    --target base \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --platform=linux/amd64,linux/arm64 \
-    --push \
-    .
-```
+1. Open https://github.com/feedforce/ruby-rpm/actions/workflows/push-docker-image.yml
+1. Run workflow with master branch
+1. Wait until workflow succeededs
+1. Open https://github.com/feedforce/ruby-rpm/pkgs/container/ruby-rpm
+1. Check that a new image has been pushed


### PR DESCRIPTION
## Why?

Docker Hub の Free Team Organization 廃止に伴う対応

See: https://web.docker.com/rs/790-SSB-375/images/privatereposfaq.pdf

## How?

ghcr.io/feedforce/ruby-rpm イメージの準備は事前に https://github.com/feedforce/ruby-rpm/compare/c362b12d249ccc40f70c2268c191294d2a77a53b...97632b4da525889cb5f244aac2a192e1a4f3a2ea で GitHub Actions を用意して master から Push 済み。

* CircleCI で使うイメージを ghcr.io/feedforce/ruby-rpm に置き換えた
* README の更新